### PR TITLE
Fix typo in GPU import helper

### DIFF
--- a/nemo/utils/import_utils.py
+++ b/nemo/utils/import_utils.py
@@ -363,7 +363,7 @@ def gpu_only_import(module, *, alt=None):
 
     return safe_import(
         module,
-        msg=f"{module} is not enabled in non GPU-enabled installations or environemnts. {GPU_INSTALL_STRING}",
+        msg=f"{module} is not enabled in non GPU-enabled installations or environments. {GPU_INSTALL_STRING}",
         alt=alt,
     )
 


### PR DESCRIPTION
## Summary
- fix misspelled "environemnts" in GPU-only import error message

## Testing
- `pre-commit run --files nemo/utils/import_utils.py` *(fails: command not found)*